### PR TITLE
Added read/write compatibility for Stata 14

### DIFF
--- a/R/stata.R
+++ b/R/stata.R
@@ -114,9 +114,12 @@ stata <- function(src = stop("At least 'src' must be specified"),
   if (dataIn)  src <- c(sprintf("use %s",  file_path_sans_ext(dtaInFile)), src)
 
   ## put a save or saveold at the end of .do if data.out == TRUE
-  if (dataOut)  src <- c(src, sprintf("%s %s",
+  ## for Stata 14, saveold defaults to a Stata 13 dta file
+  ## -> use the (Stata 14 only) saveold option: "version(12)" to allow foreign::read.dta() read compatibility
+  if (dataOut)  src <- c(src, sprintf("%s %s%s",
                                       ifelse(stataVersion >= 13, "saveold", "save"),
-                                      file_path_sans_ext(dtaOutFile) ))
+                                      file_path_sans_ext(dtaOutFile),
+                                      ifelse(stataVersion >= 14, ", version(12)", "") ))
     
   ## adding this command to the end simplify life if user make changes but
   ## doesn't want a data.frame back


### PR DESCRIPTION
For Stata 14, the `saveold` command  defaults to a Stata 13 `dta` file but the R function `foreign::read.dta()` only works for Stata<=12. Therefore by using the (Stata 14 only) `saveold` option: "`version(12)`" allows `foreign::read.dta()` compatibility.

Reference if required:
http://www.stata.com/support/faqs/data-management/save-for-previous-version/

Also, thanks for creating such a great package and making it available!
