### PR TITLE
Add option to run Stata in batch mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Imports:
     utils
 License: GPL-3
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/stata.R
+++ b/R/stata.R
@@ -9,6 +9,7 @@
 #' @param stata.path Stata command to be used
 #' @param stata.version Version of Stata used
 #' @param stata.echo logical value. If \code{TRUE} stata text output will be printed
+#' @param stata.batch logical value. if \code{TRUE} stata will run in batch mode
 #' @param ... parameter passed to \code{\link{write.dta}}
 #' @examples
 #' \dontrun{

--- a/R/stata.R
+++ b/R/stata.R
@@ -48,6 +48,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
                   stata.path = getOption("RStata.StataPath", stop("You need to set up a Stata path; ?chooseStataBin")),
                   stata.version = getOption("RStata.StataVersion", stop("You need to specify your Stata version")),
                   stata.echo = getOption("RStata.StataEcho", TRUE),
+                  stata.batch = getOption("RStata.StataBatch", FALSE),
                   ...
                   )
 {
@@ -76,6 +77,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
     dataOut <- data.out[1L]
     stataVersion <- stata.version[1L]
     stataEcho <- stata.echo[1L]
+    stataBatch <- stata.batch[1L]
 
     ## -----------------
     ## OS related config
@@ -83,9 +85,9 @@ stata <- function(src = stop("At least 'src' must be specified"),
     ## in Windows and batch mode a RStata.log (naming after RStata.do
     ## below) is generated in the current directory
 
-    if (OS %in% "Windows") {
-        winRStataLog <- "RStata.log"
-        on.exit(unlink(winRStataLog))
+    if (stataBatch | OS %in% "Windows") {
+        batchRStataLog <- "RStata.log"
+        on.exit(unlink(batchRStataLog))
     }
   
     ## -----
@@ -164,7 +166,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
     ## With Windows version, /e is almost always needed (if Stata is
     ## installed with GUI)
     stataCmd <- paste(stata.path,
-                      if (OS %in% "Windows") "/e" else "",
+                      if (OS %in% "Windows") "/e" else if (stataBatch) "-b" else "",
                       "do",
                       doFile)
   
@@ -183,7 +185,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
     close(rdl)
     
     if (stataEcho) {
-        if (OS %in% "Windows") stataLog <- readLines(winRStataLog)
+        if (stataBatch | OS %in% "Windows") stataLog <- readLines(batchRStataLog)
         ## postprocess log, keeping only the output of interest (between rows
         ## having /* RSTATA: cut me here */
         cutpoints <- grep(cut_me_here, stataLog)

--- a/man/RStata.Rd
+++ b/man/RStata.Rd
@@ -9,4 +9,3 @@
 A simple R -> Stata interface allowing the user to execute Stata
 commands (both inline and from a .do file) from R.
 }
-

--- a/man/chooseStataBin.Rd
+++ b/man/chooseStataBin.Rd
@@ -11,4 +11,3 @@ Set Stata binary (among found alternatives) path. These settings are
 lost when R is closed, therefore you should consider adding a
 \code{options("RStata.StataPath")} line in your \code{.Rprofile}.
 }
-

--- a/man/stata.Rd
+++ b/man/stata.Rd
@@ -9,7 +9,8 @@ stata(src = stop("At least 'src' must be specified"), data.in = NULL,
   stop("You need to set up a Stata path; ?chooseStataBin")),
   stata.version = getOption("RStata.StataVersion",
   stop("You need to specify your Stata version")),
-  stata.echo = getOption("RStata.StataEcho", TRUE), ...)
+  stata.echo = getOption("RStata.StataEcho", TRUE),
+  stata.batch = getOption("RStata.StataBatch", FALSE), ...)
 }
 \arguments{
 \item{src}{character vector of length 1 (path to \code{.do} file) or more
@@ -25,6 +26,8 @@ the Stata command are returned to R.}
 \item{stata.version}{Version of Stata used}
 
 \item{stata.echo}{logical value. If \code{TRUE} stata text output will be printed}
+
+\item{stata.batch}{logical value. if \code{TRUE} stata will run in batch mode}
 
 \item{...}{parameter passed to \code{\link{write.dta}}}
 }
@@ -63,4 +66,3 @@ head(auto)
 (y <- stata("replace a = 2", data.in = x, data.out = TRUE))
 }
 }
-


### PR DESCRIPTION
It is possible to run Stata in batch mode in unix and Mac OS. This mode sends the program output to a log file (much like using the /s option in windows).

This pull requests adds a logical argument to allow to run Stata in batch mode. This option is set to FALSE by default to keep the current RStata behavior. If set to TRUE, RStata will read the contents of the RStata.log instead of relying on the sys call output. This also fixes the issue of RStata hanging when the user has set more on.

I have tested this on MacOS and it seems to work.