### PR TITLE
Incorporates option to import Stata estimation results into R.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,3 @@
 ^\.travis\.yml
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ BugReports: http://github.com/lbraglia/RStata/issues
 Imports:
     foreign,
     tools,
-    utils
+    utils,
+    readxl
 License: GPL-3
 LazyData: true
 RoxygenNote: 6.0.1

--- a/R/addReturns.R
+++ b/R/addReturns.R
@@ -149,7 +149,9 @@ get_stata_returns <- function(file){
       
       matname <- paste0(s_token[4:length(s_token)], collapse = '_')
       insheet <- as.data.frame(insheet)
-      rownames(insheet) <- insheet[,1]
+      rnames <- insheet[,1] 
+      rnames[is.na(rnames)] <- ''
+      rownames(insheet) <- rnames
       insheet <- insheet[,-1, drop=F] 
       insheet <- as.matrix(insheet)
       

--- a/R/addReturns.R
+++ b/R/addReturns.R
@@ -4,14 +4,14 @@ out <- c(SRC,"local est_name \"Active\"
 
 ***Rreturns***
   local returns : r(scalars)
-putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_scalars\") modify
+version 13: putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_scalars\") modify
 local i = 1
 foreach e in `returns'{
 	cap confirm scalar r(`e')
 if !_rc{
   
-  putexcel A`i' = \"`e'\"
-		putexcel B`i' = `r(`e')'
+  version 13: putexcel A`i' = (\"`e'\")
+		version 13: putexcel B`i' = (`r(`e')')
 		local ++i
 } 
 
@@ -19,32 +19,32 @@ if !_rc{
 
 local returns : r(matrices)
 foreach e in `returns' { 
-	putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_matrix_`e'\") modify
-	putexcel A1 = matrix(r(`e')'), names
+	version 13: putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_matrix_`e'\") modify
+	version 13: putexcel A1 = matrix(r(`e')', names)
 }
 
 ***Ereturns***
 
 local returns : e(scalars)
-putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_scalars\") modify
+version 13: putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_scalars\") modify
 local i = 1
 foreach e in `returns'{
 	cap confirm scalar e(`e')
 	if !_rc{
 
-		putexcel A`i' = \"`e'\"
-		putexcel B`i' = `e(`e')'
+		version 13: putexcel A`i' = (\"`e'\")
+		version 13: putexcel B`i' = (`e(`e')')
 		local ++i
 		} 
 
 }
 
 local returns : e(macros)
-putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_macros\") modify
+version 13: putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_macros\") modify
 local i = 1
 foreach e in `returns'{
-		putexcel A`i' = \"`e'\"
-putexcel B`i' = \"`e(`e')'\"
+		version 13: putexcel A`i' = (\"`e'\")
+version 13: putexcel B`i' = (\"`e(`e')'\")
 
 	local ++i
 }
@@ -53,8 +53,8 @@ putexcel B`i' = \"`e(`e')'\"
 local returns : e(matrices)
  
 foreach e in `returns' { 
-	putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_matrix_`e'\") modify
-	putexcel A1 = matrix(e(`e')'), names
+	version 13: putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_matrix_`e'\") modify
+	version 13: putexcel A1 = matrix(e(`e')', names)
 }
 
 
@@ -65,14 +65,14 @@ foreach n in `r(names)'{
   estimates restore `n'
 	
 	local returns : r(scalars)
-	putexcel set ReturnsToR.xls, sheet(\"`n'_r_scalars\") modify
+	version 13: putexcel set ReturnsToR.xls, sheet(\"`n'_r_scalars\") modify
 	local i = 1
 	foreach e in `returns'{
 		cap confirm scalar r(`e')
 		if !_rc{
 
-			putexcel A`i' = \"`e'\"
-			putexcel B`i' = `r(`e')'
+			version 13: putexcel A`i' = (\"`e'\")
+			version 13: putexcel B`i' = (`r(`e')')
 			local ++i
 } 
 
@@ -82,32 +82,32 @@ foreach n in `r(names)'{
 
 local returns : r(matrices)
 foreach e in `returns' { 
-		putexcel set ReturnsToR.xls, sheet(\"`n'_r_matrix_`e'\") modify
-		putexcel A1 = matrix(r(`e')'), names
+		version 13: putexcel set ReturnsToR.xls, sheet(\"`n'_r_matrix_`e'\") modify
+		version 13: putexcel A1 = matrix(r(`e')', names)
 	}
 
 	***Ereturns***
 
 	local returns : e(scalars)
-	putexcel set ReturnsToR.xls, sheet(\"`n'_e_scalars\") modify
+	version 13: putexcel set ReturnsToR.xls, sheet(\"`n'_e_scalars\") modify
 	local i = 1
 	foreach e in `returns'{
 		cap confirm scalar e(`e')
 		if !_rc{
 
-			putexcel A`i' = \"`e'\"
-			putexcel B`i' = `e(`e')'
+			version 13: putexcel A`i' = (\"`e'\")
+			version 13: putexcel B`i' = (`e(`e')')
 			local ++i
 			} 
 
 }
 
 local returns : e(macros)
-putexcel set ReturnsToR.xls, sheet(\"`n'_e_macros\") modify
+version 13: putexcel set ReturnsToR.xls, sheet(\"`n'_e_macros\") modify
 local i = 1
 foreach e in `returns'{
-			putexcel A`i' = \"`e'\"
-putexcel B`i' = \"`e(`e')'\"
+			version 13: putexcel A`i' = (\"`e'\")
+version 13: putexcel B`i' = (\"`e(`e')'\")
 
 		local ++i
 	}
@@ -116,8 +116,8 @@ putexcel B`i' = \"`e(`e')'\"
 	local returns : e(matrices)
 	 
 	foreach e in `returns' { 
-		putexcel set ReturnsToR.xls, sheet(\"`n'_e_matrix_`e'\") modify
-		putexcel A1 = matrix(e(`e')'), names
+		version 13: putexcel set ReturnsToR.xls, sheet(\"`n'_e_matrix_`e'\") modify
+		version 13: putexcel A1 = matrix(e(`e')', names)
 	}
 
 }"
@@ -149,11 +149,34 @@ get_stata_returns <- function(file){
       
       matname <- paste0(s_token[4:length(s_token)], collapse = '_')
       insheet <- as.data.frame(insheet)
-      rnames <- insheet[,1] 
+      
+
+      while (all(grepl('[A-Z, a-z]', insheet[1,])|is.na(insheet[1,]))){
+        colnames(insheet) <- paste(colnames(insheet), insheet[1,], sep = '_')
+        insheet <- insheet[-1,]
+
+      }
+      
+      while (all(grepl('[A-Z, a-z]', insheet[[2]])|is.na(insheet[[2]]))){
+        insheet[,1] <- do.call(paste, c(insheet[1:2], sep='_'))
+        insheet <- insheet[,-2]
+        
+      }
+      
+   
+      
+      
+      rnames <- insheet[[1]] 
       rnames[is.na(rnames)] <- ''
       rownames(insheet) <- rnames
       insheet <- insheet[,-1, drop=F] 
-      insheet <- as.matrix(insheet)
+      
+      for (c in 1:ncol(insheet)){
+        insheet[[c]] <- as.numeric(insheet[[c]])
+      }
+      
+      
+      insheet <- as.matrix(insheet) 
       
       out[[s_token[1]]][[s_token[2]]][[s_token[3]]][[matname]] <- insheet
     }

--- a/R/addReturns.R
+++ b/R/addReturns.R
@@ -1,0 +1,162 @@
+stata_return_code <- function(SRC) { 
+  
+out <- c(SRC,"local est_name \"Active\"
+
+***Rreturns***
+  local returns : r(scalars)
+putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_scalars\") modify
+local i = 1
+foreach e in `returns'{
+	cap confirm scalar r(`e')
+if !_rc{
+  
+  putexcel A`i' = \"`e'\"
+		putexcel B`i' = `r(`e')'
+		local ++i
+} 
+
+}
+
+local returns : r(matrices)
+foreach e in `returns' { 
+	putexcel set ReturnsToR.xls, sheet(\"`est_name'_r_matrix_`e'\") modify
+	putexcel A1 = matrix(r(`e')'), names
+}
+
+***Ereturns***
+
+local returns : e(scalars)
+putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_scalars\") modify
+local i = 1
+foreach e in `returns'{
+	cap confirm scalar e(`e')
+	if !_rc{
+
+		putexcel A`i' = \"`e'\"
+		putexcel B`i' = `e(`e')'
+		local ++i
+		} 
+
+}
+
+local returns : e(macros)
+putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_macros\") modify
+local i = 1
+foreach e in `returns'{
+		putexcel A`i' = \"`e'\"
+putexcel B`i' = \"`e(`e')'\"
+
+	local ++i
+}
+
+
+local returns : e(matrices)
+ 
+foreach e in `returns' { 
+	putexcel set ReturnsToR.xls, sheet(\"`est_name'_e_matrix_`e'\") modify
+	putexcel A1 = matrix(e(`e')'), names
+}
+
+
+************************Stored Returns************************************
+estimates dir
+foreach n in `r(names)'{
+  
+  estimates restore `n'
+	
+	local returns : r(scalars)
+	putexcel set ReturnsToR.xls, sheet(\"`n'_r_scalars\") modify
+	local i = 1
+	foreach e in `returns'{
+		cap confirm scalar r(`e')
+		if !_rc{
+
+			putexcel A`i' = \"`e'\"
+			putexcel B`i' = `r(`e')'
+			local ++i
+} 
+
+}
+
+
+
+local returns : r(matrices)
+foreach e in `returns' { 
+		putexcel set ReturnsToR.xls, sheet(\"`n'_r_matrix_`e'\") modify
+		putexcel A1 = matrix(r(`e')'), names
+	}
+
+	***Ereturns***
+
+	local returns : e(scalars)
+	putexcel set ReturnsToR.xls, sheet(\"`n'_e_scalars\") modify
+	local i = 1
+	foreach e in `returns'{
+		cap confirm scalar e(`e')
+		if !_rc{
+
+			putexcel A`i' = \"`e'\"
+			putexcel B`i' = `e(`e')'
+			local ++i
+			} 
+
+}
+
+local returns : e(macros)
+putexcel set ReturnsToR.xls, sheet(\"`n'_e_macros\") modify
+local i = 1
+foreach e in `returns'{
+			putexcel A`i' = \"`e'\"
+putexcel B`i' = \"`e(`e')'\"
+
+		local ++i
+	}
+
+
+	local returns : e(matrices)
+	 
+	foreach e in `returns' { 
+		putexcel set ReturnsToR.xls, sheet(\"`n'_e_matrix_`e'\") modify
+		putexcel A1 = matrix(e(`e')'), names
+	}
+
+}"
+)
+
+out <- unlist(lapply(out, strsplit, '\n'))
+return(out)
+}
+
+get_stata_returns <- function(file){  
+  library(stringr, quietly = T)
+
+  sheets <- readxl::excel_sheets(file)
+  
+  out <- list()
+  
+  for (s in sheets){
+    s_token <- unlist(strsplit(s, '_'))
+
+    if( s_token[3] %in% c('scalars', 'macros')){    
+      insheet <- suppressMessages(readxl::read_excel(file, sheet = s, col_names = F))
+
+      scalars <- insheet$...2
+      names(scalars) <- insheet$...1
+      out[[s_token[1]]][[s_token[2]]][[s_token[3]]] <- scalars
+    } 
+    else {
+      insheet <- suppressMessages(readxl::read_excel(file, sheet = s))
+      
+      matname <- paste0(s_token[4:length(s_token)], collapse = '_')
+      insheet <- as.data.frame(insheet)
+      rownames(insheet) <- insheet[,1]
+      insheet <- insheet[,-1, drop=F] 
+      insheet <- as.matrix(insheet)
+      
+      out[[s_token[1]]][[s_token[2]]][[s_token[3]]][[matname]] <- insheet
+    }
+    
+  }
+  
+  invisible(out)
+}

--- a/man/stata.Rd
+++ b/man/stata.Rd
@@ -5,7 +5,7 @@
 \title{Send commands to a Stata process}
 \usage{
 stata(src = stop("At least 'src' must be specified"), data.in = NULL,
-  data.out = FALSE, stata.path = getOption("RStata.StataPath",
+  data.out = FALSE, returns.out = FALSE, stata.path = getOption("RStata.StataPath",
   stop("You need to set up a Stata path; ?chooseStataBin")),
   stata.version = getOption("RStata.StataVersion",
   stop("You need to specify your Stata version")),

--- a/man/stata.Rd
+++ b/man/stata.Rd
@@ -20,6 +20,11 @@ stata(src = stop("At least 'src' must be specified"), data.in = NULL,
 \item{data.out}{logical value. If \code{TRUE}, the data at the end of
 the Stata command are returned to R.}
 
+\item{returns.out}{logical value. If \code{TRUE}, the stored results for the 
+active estimation and any previous results stored using the 'estimates store'
+command are returned to R as a list.  If specified with data.out, the first
+item of the returned list will be the data and the second item will be the returns.}
+
 \item{stata.path}{Stata command to be used}
 
 \item{stata.version}{Version of Stata used}
@@ -34,7 +39,7 @@ Function that sends commands to a Stata process.
 \examples{
 \dontrun{
 ## Single command
-stata("help regress") #<- this won't work in Windows dued to needed
+stata("help regress") #<- this won't work in Windows due to needed
                       #   batch mode
 
 ## Many commands
@@ -58,6 +63,10 @@ stata( "sum a", data.in = x)
 ## Data output from Stata (eg obtain 'auto' dataset)
 auto <- stata("sysuse auto", data.out = TRUE)
 head(auto)
+
+## Return estimates from Stata (eg obtain return and ereturn scalars and matrices)
+auto <- stata("sysuse auto
+reg price mpg", return.out = TRUE)
 
 ## Data input/output
 (y <- stata("replace a = 2", data.in = x, data.out = TRUE))


### PR DESCRIPTION
Allows users to run analyses in Stata and directly import the results for further processing, reporting, or plotting in R.  The addition adds the relevant option, returns.out, to the stata() function.  If selected, Stata code is appended to the SRC object which loops through the active and stored return and ereturn results in Stata and writes them to an excel file.  Then the excel file is read into a list in R and returned as the output.  

If both data.out and returns.out are selected, a list is returned in which the first element is the data frame from the data.out option and the second element is the returns list.

On a side note, this is my first time using Github to contribute to a project, so please forgive any breaches of etiquette. 