### PR TITLE
Update stata.R

### DIFF
--- a/R/stata.R
+++ b/R/stata.R
@@ -48,6 +48,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
                   stata.path = getOption("RStata.StataPath", stop("You need to set up a Stata path; ?chooseStataBin")),
                   stata.version = getOption("RStata.StataVersion", stop("You need to specify your Stata version")),
                   stata.echo = getOption("RStata.StataEcho", TRUE),
+                  dofile.name = "RStata.do",
                   ...
                   )
 {
@@ -94,7 +95,7 @@ stata <- function(src = stop("At least 'src' must be specified"),
 
     ## tempfile could be misleading if the do source other dos 
     ## with relative paths
-    doFile <- "RStata.do"
+    doFile <- dofile.name
     on.exit(unlink(doFile), add = TRUE)
 
     if (dataIn){


### PR DESCRIPTION
Added a new arg "dofile.name" that allows a custom do-file name in multi-session situations. The default value is still "RStata.do". I am running 10 sessions simultaneously, all of which competed for RStata.do filename and crashing. This simple fix provides a go-around for this problem.